### PR TITLE
Dev merge to master, PR (#3638)

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -62,3 +62,6 @@
  * eevee-github
  * g0vanish
  * cmezh
+ * Nivong
+ * kestel
+ * joaodragao

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM python:2.7-onbuild
+FROM python:2.7
+
+WORKDIR /usr/src/app
+VOLUME ["/usr/app/configs", "/usr/src/app/web"]
 
 ARG timezone=Etc/UTC
 RUN echo $timezone > /etc/timezone \
@@ -15,8 +18,11 @@ RUN cd /tmp && wget "http://pgoapi.com/pgoencrypt.tar.gz" \
     && cd /tmp \
     && rm -rf /tmp/pgoencrypt*
 
-VOLUME ["/usr/src/app/web"]
-
 ENV LD_LIBRARY_PATH /usr/src/app
+
+COPY requirements.txt /usr/src/app/
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . /usr/src/app
 
 ENTRYPOINT ["python", "pokecli.py"]

--- a/README.md
+++ b/README.md
@@ -1,18 +1,14 @@
-
-# PokemonGo-Bot (Working)
+# PokemonGo-Bot
 PokemonGo bot is a project created by the [PokemonGoF](https://github.com/PokemonGoF) team.
-The project is currently setup in two main branches. `dev` and `master`.
 
-## Help Needed on [Desktop Version](https://github.com/PokemonGoF/PokemonGo-Bot-Desktop)
+The project is currently setup in two main branches. `dev` also known as `beta` and `master` also known as `stable`. Submit your PR's to `dev`.
 
-## Please submit PR to [Dev branch](https://github.com/PokemonGoF/PokemonGo-Bot/tree/dev)
-
-We use [Slack](https://slack.com) as a web chat. [Click here to join the chat!](https://pokemongo-bot.herokuapp.com)
-You can count on the community in #help channel.
+If you need any help please don't create an issue here on github we have a great community on Slack, [Click here to join the chat!](https://pokemongo-bot.herokuapp.com). You can count on the community in #help channel.
 
 ## Table of Contents
+- [Installation](https://github.com/PokemonGoF/PokemonGo-Bot/blob/dev/docs/installation.md)
+- [Documentation](https://github.com/PokemonGoF/PokemonGo-Bot/blob/dev/docs/)
 - [Features](#features)
-- [Wiki](#wiki)
 - [Credits](#credits)
 
 ## Features
@@ -27,9 +23,9 @@ You can count on the community in #help channel.
 - [x] Rudimentary IV Functionality filter
 - [x] Ignore certain pokemon filter
 - [x] Adjust delay between Pokemon capture & Transfer as per configuration
-- [ ] Standalone Desktop Application
 - [x] Hatch eggs
 - [x] Incubate eggs
+- [ ] [Standalone Desktop Application] (https://github.com/PokemonGoF/PokemonGo-Bot-Desktop)
 - [ ] Use candy
 - [ ] Inventory cleaner
 
@@ -45,22 +41,8 @@ If there are any concerns with this policy or you believe we are tracking someth
 
 If you do not want any data to be gathered, you can turn off this feature by setting `health_record` to `false` in your `config.json`.
 
-## Wiki
-All information on [Getting Started](https://github.com/PokemonGoF/PokemonGo-Bot/wiki/Getting-Started) is available in the [Wiki](https://github.com/PokemonGoF/PokemonGo-Bot/wiki/)!
-- __Installation__
-  - [Requirements] (https://github.com/PokemonGoF/PokemonGo-Bot/wiki/Installation#requirements-click-each-one-for-install-guide)
-  - [How to run with Docker](https://github.com/PokemonGoF/PokemonGo-Bot/wiki/How-to-run-with-Docker)
-  - [Linux] (https://github.com/PokemonGoF/PokemonGo-Bot/wiki/Installation#installation-linux)
-  - [Mac] (https://github.com/PokemonGoF/PokemonGo-Bot/wiki/Installation#installation-mac)
-  - [Windows] (https://github.com/PokemonGoF/PokemonGo-Bot/wiki/Installation#installation-windows)
-- [Develop PokemonGo-Bot](https://github.com/PokemonGoF/PokemonGo-Bot/wiki/Develop-PokemonGo-Bot)
-- [Plugins](https://github.com/PokemonGoF/PokemonGo-Bot/blob/dev/docs/plugins.md)
-- [Configuration-files](https://github.com/PokemonGoF/PokemonGo-Bot/wiki/Configuration-files)
-- [Front end web module - Google Maps API] (https://github.com/PokemonGoF/PokemonGo-Bot/wiki/Google-Maps-API-(web-page))
-- [Docker Usage](https://github.com/PokemonGoF/PokemonGo-Bot/wiki/FAQ#how-to-run-with-docker)
-- [FAQ](https://github.com/PokemonGoF/PokemonGo-Bot/wiki/FAQ)
+## Help Needed on [Desktop Version](https://github.com/PokemonGoF/PokemonGo-Bot-Desktop)
 
-To ensure that all updates are documented - [@eggins](https://github.com/eggins) will keep the Wiki updated with the latest information on installing, updating and configuring the bot.
 
 ## Credits
 - [tejado](https://github.com/tejado) many thanks for the API

--- a/configs/config.json.cluster.example
+++ b/configs/config.json.cluster.example
@@ -10,12 +10,32 @@
         "type": "HandleSoftBan"
       },
       {
+        "type": "SleepSchedule",
+        "config": {
+          "enabled": false,
+          "time": "22:54",
+          "duration":"7:46",
+          "time_random_offset": "00:24",
+          "duration_random_offset": "00:43"
+        }
+      },
+      {
         "type": "CollectLevelUpReward"
       },
       {
         "type": "IncubateEggs",
         "config": {
           "longer_eggs_first": true
+        }
+      },
+      {
+        "type": "UpdateLiveStats",
+        "config": {
+          "enabled": false,
+          "min_interval": 10,
+          "stats": ["uptime", "stardust_earned", "xp_earned", "xp_per_hour", "stops_visited"],
+          "terminal_log": true,
+          "terminal_title": true
         }
       },
       {
@@ -78,7 +98,6 @@
     "location_cache": true,
     "distance_unit": "km",
     "reconnecting_timeout": 15,
-    "evolve_captured": "NONE",
     "catch_randomize_reticle_factor": 1.0,
     "catch_randomize_spin_factor": 1.0,
     "logging_color": true,

--- a/configs/config.json.example
+++ b/configs/config.json.example
@@ -10,12 +10,32 @@
         "type": "HandleSoftBan"
       },
       {
+        "type": "SleepSchedule",
+        "config": {
+          "enabled": false,
+          "time": "22:54",
+          "duration":"7:46",
+          "time_random_offset": "00:24",
+          "duration_random_offset": "00:43"
+        }
+      },
+      {
         "type": "CollectLevelUpReward"
       },
       {
         "type": "IncubateEggs",
         "config": {
           "longer_eggs_first": true
+        }
+      },
+      {
+        "type": "UpdateLiveStats",
+        "config": {
+          "enabled": false,
+          "min_interval": 10,
+          "stats": ["uptime", "stardust_earned", "xp_earned", "xp_per_hour", "stops_visited"],
+          "terminal_log": true,
+          "terminal_title": true
         }
       },
       {
@@ -93,7 +113,6 @@
     "location_cache": true,
     "distance_unit": "km",
     "reconnecting_timeout": 15,
-    "evolve_captured": "NONE",
     "catch_randomize_reticle_factor": 1.0,
     "catch_randomize_spin_factor": 1.0,
     "logging_color": true,

--- a/configs/config.json.map.example
+++ b/configs/config.json.map.example
@@ -10,12 +10,32 @@
         "type": "HandleSoftBan"
       },
       {
+        "type": "SleepSchedule",
+        "config": {
+          "enabled": false,
+          "time": "22:54",
+          "duration":"7:46",
+          "time_random_offset": "00:24",
+          "duration_random_offset": "00:43"
+        }
+      },
+      {
         "type": "CollectLevelUpReward"
       },
       {
         "type": "IncubateEggs",
         "config": {
           "longer_eggs_first": true
+        }
+      },
+      {
+        "type": "UpdateLiveStats",
+        "config": {
+          "enabled": false,
+          "min_interval": 10,
+          "stats": ["uptime", "stardust_earned", "xp_earned", "xp_per_hour", "stops_visited"],
+          "terminal_log": true,
+          "terminal_title": true
         }
       },
       {
@@ -320,7 +340,6 @@
     "location_cache": true,
     "distance_unit": "km",
     "reconnecting_timeout": 15,
-    "evolve_captured": "NONE",
     "catch_randomize_reticle_factor": 1.0,
     "catch_randomize_spin_factor": 1.0,
     "logging_color": true,

--- a/configs/config.json.path.example
+++ b/configs/config.json.path.example
@@ -10,12 +10,32 @@
         "type": "HandleSoftBan"
       },
       {
+        "type": "SleepSchedule",
+        "config": {
+          "enabled": false,
+          "time": "22:54",
+          "duration":"7:46",
+          "time_random_offset": "00:24",
+          "duration_random_offset": "00:43"
+        }
+      },
+      {
         "type": "CollectLevelUpReward"
       },
       {
         "type": "IncubateEggs",
         "config": {
           "longer_eggs_first": true
+        }
+      },
+      {
+        "type": "UpdateLiveStats",
+        "config": {
+          "enabled": false,
+          "min_interval": 10,
+          "stats": ["uptime", "stardust_earned", "xp_earned", "xp_per_hour", "stops_visited"],
+          "terminal_log": true,
+          "terminal_title": true
         }
       },
       {
@@ -80,7 +100,6 @@
     "location_cache": true,
     "distance_unit": "km",
     "reconnecting_timeout": 15,
-    "evolve_captured": "NONE",
     "catch_randomize_reticle_factor": 1.0,
     "catch_randomize_spin_factor": 1.0,
     "logging_color": true,

--- a/configs/config.json.pokemon.example
+++ b/configs/config.json.pokemon.example
@@ -10,12 +10,32 @@
         "type": "HandleSoftBan"
       },
       {
+        "type": "SleepSchedule",
+        "config": {
+          "enabled": false,
+          "time": "22:54",
+          "duration":"7:46",
+          "time_random_offset": "00:24",
+          "duration_random_offset": "00:43"
+        }
+      },
+      {
         "type": "CollectLevelUpReward"
       },
       {
         "type": "IncubateEggs",
         "config": {
           "longer_eggs_first": true
+        }
+      },
+      {
+        "type": "UpdateLiveStats",
+        "config": {
+          "enabled": false,
+          "min_interval": 10,
+          "stats": ["uptime", "stardust_earned", "xp_earned", "xp_per_hour", "stops_visited"],
+          "terminal_log": true,
+          "terminal_title": true
         }
       },
       {
@@ -86,7 +106,6 @@
     "location_cache": true,
     "distance_unit": "km",
     "reconnecting_timeout": 15,
-    "evolve_captured": "NONE",
     "catch_randomize_reticle_factor": 1.0,
     "catch_randomize_spin_factor": 1.0,
     "logging_color": true,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,8 @@ services:
   bot1-pokego:
     build: .
     volumes:
-     - ./configs/config.json:/usr/src/app/configs/config.json
+     - ./configs:/usr/src/app/configs
+     - ./web:/usr/src/app/web
     stdin_open: true
     tty: true
   bot1-pokegoweb:
@@ -11,9 +12,9 @@ services:
     ports:
      - "8000:8000"
     volumes_from:
-     - bot1-pokego
+      - bot1-pokego
     volumes:
-     - ./configs/userdata.js:/usr/src/app/web/config/userdata.js
+      - ./configs:/usr/src/app/web/config
     working_dir: /usr/src/app/web
     command: bash -c "echo 'Serving HTTP on 0.0.0.0 port 8000' && python -m SimpleHTTPServer > /dev/null 2>&1"
     depends_on:

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,17 +1,34 @@
-Start by downloading for your platform: [Mac](https://www.docker.com/products/docker#/mac), [Windows](https://www.docker.com/products/docker#/windows), or [Linux](https://www.docker.com/products/docker#/linux). Once you have Docker installed, simply create the various config.json files for your different accounts (e.g. `configs/config-account1.json`) and then create a Docker image for PokemonGo-Bot using the Dockerfile in this repo.
+Start by downloading for your platform: [Mac](https://www.docker.com/products/docker#/mac), [Windows](https://www.docker.com/products/docker#/windows), or [Linux](https://www.docker.com/products/docker#/linux). Once you have Docker installed, simply create the various config.json files for your different accounts (e.g. `configs/config-account1.json`) and then create a Docker image for PokemonGo-Bot using the Dockerfile in this [repo](https://hub.docker.com/r/svlentink/pokemongo-bot/).
+
+#Setup
+##Automatic setup
+Use this docker hub url: https://hub.docker.com/r/svlentink/pokemongo-bot/
+```
+docker pull svlentink/pokemongo-bot
+```
+
+##Manual setup
 ```
 cd PokemonGo-Bot
 docker build -t pokemongo-bot .
 ```
+
+#Run
+
 You can verify that the image was created with:
 ```
 docker images
 ```
+- In case of automatic setup, you'll see an image called: `svlentink/pokemongo-bot`
+- In case of manual setup, you'll see an image called: `pokemongo-bot`
 
 To run PokemonGo-Bot Docker image you've created, simple run:
 ```
-docker run --name=pokego-bot1 --rm -it -v $(pwd)/configs/config-account1.json:/usr/src/app/configs/config.json pokemongo-bot
+docker run --name=pokego-bot1 --rm -it -v $(pwd)/configs/config-account1.json:/usr/src/app/configs/config.json -v $(pwd)/data:/usr/src/app/data pokemongo-bot
 ```
+
+Replace `pokemongo-bot` with `svlentink/pokemongo-bot` in case you followed automatic setup.
+
 _Check the logs in real-time `docker logs -f pgobot`_
 
 If you want to run multiple accounts with the same Docker image, simply specify different config.json and names in the Docker run command.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,7 +1,12 @@
 ### How do I start the application?
-After customizing your config.json files, cd to the PokemonGo-Bot folder and enter:
+After [installing] (https://github.com/PokemonGoF/PokemonGo-Bot/blob/dev/docs/installation.md), in the root folder run the following command:
+### Linux
 ```
-$ python pokecli.py
+run.sh
+```
+### Windows
+```
+run.bat
 ```
 This will start the application.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -7,6 +7,26 @@
 - [docker](https://docs.docker.com/engine/installation/) (Optional) - [how to setup after installation](https://github.com/PokemonGoF/PokemonGo-Bot/wiki/How-to-run-with-Docker)
 - [protobuf 3](https://github.com/google/protobuf) (OS Dependent, see below)
 
+#Linux/Mac Automatic installation
+### Easy installation
+1. Run setup.sh -e
+    This will create the needed encrypted.so file
+2. Run setup.sh -i
+    This will install the bot and all stuff that is needed to run it (follow the guide)
+3. Run setup.sh -c
+    This will make the config file needed, only basic stuff is changed here. If you want to edit more edit this file after: config/config.json
+4. Run run.sh
+    This will run the bot and will start leveling your pokemon go account.
+
+### To update
+1. Stop the bot if it's running. (use control + c twice to stop it)
+2. Run setup.sh -r
+    This will reset and makes sure you have no changes made to any code since it will overide it
+3. Run setup.sh -u
+    This will run git pull and will update to the new git update.
+
+
+# Manual installation
 ### Protobuf 3 installation
 
 - OS X:  `brew update && brew install --devel protobuf`
@@ -29,20 +49,71 @@ To update your project do (in the project folder): `git pull`
 
 To update python requirement packages do (in the project folder): `pip install --upgrade -r requirements.txt`
 
-### Installation Linux
-(change master to dev for the latest version)
-
-```
-$ git clone --recursive -b master https://github.com/PokemonGoF/PokemonGo-Bot
-$ cd PokemonGo-Bot
-$ virtualenv .
-$ source bin/activate
-$ pip install -r requirements.txt
-```
-#### Example Installation for Ubuntu
+### Linux Installation
+####on the Example of Ubuntu
 (change dev to master for the lastest master version)
 
-http://pastebin.com/pzPjXT65
+if you are on a different Linux OS you maybe have to adapt things like:
+
+- package mananger (for example yum instead of apt-get)
+- package names
+
+```bash
+##install
+#change to root
+sudo -i
+#go to your home directory with the console
+apt-get install build-essential autoconf libtool pkg-config make python-dev python-protobuf python2.7 wget git
+#install pip
+wget https://bootstrap.pypa.io/get-pip.py
+python2.7 get-pip.py
+rm -f get-pip.py
+#get git repo
+git clone --recursive -b dev https://github.com/PokemonGoF/PokemonGo-Bot  
+cd PokemonGo-Bot
+#install and enable virtualenv
+#You need to make shure your python version and virtualenv verison work together
+#install virtualenv and activate it
+pip install virtualenv
+virtualenv .
+source bin/activate
+#then install the requierements
+pip install -r requirements.txt
+ 
+##get the encryption.so and move to right folder
+wget http://pgoapi.com/pgoencrypt.tar.gz
+tar -xzvf pgoencrypt.tar.gz
+cd pgoencrypt/src/
+make
+cd ../../
+#make the encrypt able to load
+mv pgoencrypt/src/libencrypt.so encrypt.so
+ 
+##edit the configuration file
+cp configs/config.json.example configs/config.json
+vi configs/config.json
+# gedit is possible too with 'gedit configs/config.json'
+#edit "google" to "ptc" if you have a pokemon trainer account
+#edit all settings
+ 
+ 
+##update to newest
+#if you need to do more i'll update this file
+#make shure virtualenv is enabled and you are in the correct folder
+git pull
+pip install -r requirements.txt
+ 
+##start the bot
+./run.sh configs/config.json
+ 
+##after reboot or closing the terminal
+#at every new start go into the folder of the PokemonGo-Bot by
+#going into the folder where you startet installing it an then
+cd PokemonGo-Bot
+#activate virtualenv and start
+source bin/activate
+./run.sh configs/config.json
+```
 
 
 ### Installation Mac

--- a/pokecli.py
+++ b/pokecli.py
@@ -329,15 +329,6 @@ def init_config():
     add_config(
         parser,
         load,
-        short_flag="-ec",
-        long_flag="--evolve_captured",
-        help="(Ad-hoc mode) Pass \"all\" or a list of pokemon to evolve (e.g., \"Pidgey,Weedle,Caterpie\"). Bot will attempt to evolve all the pokemon captured!",
-        type=str,
-        default=[]
-    )
-    add_config(
-        parser,
-        load,
         short_flag="-rt",
         long_flag="--reconnecting_timeout",
         help="Timeout between reconnecting if error occured (in minutes, e.g. 15)",
@@ -453,12 +444,8 @@ def init_config():
             task_configuration_error('{}.{}'.format(outer, inner))
             return None
 
-    if (config.evolve_captured
-        and (not isinstance(config.evolve_captured, str)
-             or str(config.evolve_captured).lower() in ["true", "false"])):
-        parser.error('"evolve_captured" should be list of pokemons: use "all" or "none" to match all ' +
-                     'or none of the pokemons, or use a comma separated list such as "Pidgey,Weedle,Caterpie"')
-        return None
+    if "evolve_captured" in load:
+        logger.warning('The evolve_captured argument is no longer supported. Please use the EvolvePokemon task instead')
 
     if not (config.location or config.location_cache):
         parser.error("Needs either --use-location-cache or --location.")
@@ -482,9 +469,6 @@ def init_config():
     except OSError:
         if not os.path.isdir(web_dir):
             raise
-
-    if config.evolve_captured and isinstance(config.evolve_captured, str):
-        config.evolve_captured = [str(pokemon_name).strip() for pokemon_name in config.evolve_captured.split(',')]
 
     fix_nested_config(config)
     return config

--- a/pokemongo_bot/__init__.py
+++ b/pokemongo_bot/__init__.py
@@ -183,7 +183,8 @@ class PokemonGoBot(object):
             'moving_to_fort',
             parameters=(
                 'fort_name',
-                'distance'
+                'distance',
+                'current_position'
             )
         )
         self.event_manager.register_event(
@@ -191,7 +192,8 @@ class PokemonGoBot(object):
             parameters=(
                 'fort_name',
                 'distance',
-                'lure_distance'
+                'lure_distance',
+                'current_position'
             )
         )
         self.event_manager.register_event(
@@ -217,7 +219,12 @@ class PokemonGoBot(object):
             parameters=('status_code',)
         )
         self.event_manager.register_event('pokestop_searching_too_often')
-        self.event_manager.register_event('arrived_at_fort')
+        self.event_manager.register_event(
+            'arrived_at_fort',
+            parameters=(
+                'current_position'
+            )
+        )
 
         # pokemon stuff
         self.event_manager.register_event(
@@ -300,10 +307,6 @@ class PokemonGoBot(object):
         self.event_manager.register_event(
             'pokemon_evolved',
             parameters=('pokemon', 'iv', 'cp')
-        )
-        self.event_manager.register_event(
-            'pokemon_evolve_fail',
-            parameters=('pokemon',)
         )
         self.event_manager.register_event('skip_evolve')
         self.event_manager.register_event('threw_berry_failed', parameters=('status_code',))

--- a/pokemongo_bot/cell_workers/__init__.py
+++ b/pokemongo_bot/cell_workers/__init__.py
@@ -17,4 +17,4 @@ from follow_spiral import FollowSpiral
 from collect_level_up_reward import CollectLevelUpReward
 from follow_cluster import FollowCluster
 from sleep_schedule import SleepSchedule
-from update_title_stats import UpdateTitleStats
+from update_live_stats import UpdateLiveStats

--- a/pokemongo_bot/cell_workers/handle_soft_ban.py
+++ b/pokemongo_bot/cell_workers/handle_soft_ban.py
@@ -29,7 +29,7 @@ class HandleSoftBan(BaseTask):
         )
 
         if fort_distance > Constants.MAX_DISTANCE_FORT_IS_REACHABLE:
-            MoveToFort(self.bot, config=None).work()
+            MoveToFort(self.bot, config={}).work()
             self.bot.recent_forts = self.bot.recent_forts[0:-1]
             if forts[0]['id'] in self.bot.fort_timeouts:
                 del self.bot.fort_timeouts[forts[0]['id']]

--- a/pokemongo_bot/cell_workers/move_to_fort.py
+++ b/pokemongo_bot/cell_workers/move_to_fort.py
@@ -61,6 +61,7 @@ class MoveToFort(BaseTask):
             fort_event_data = {
                 'fort_name': u"{}".format(fort_name),
                 'distance': format_dist(dist, unit),
+                'current_position': self.bot.position
             }
 
             if self.is_attracted() > 0:
@@ -87,9 +88,13 @@ class MoveToFort(BaseTask):
             if not step_walker.step():
                 return WorkerResult.RUNNING
 
+        arrived_at_fort_data = {
+            'current_position': self.bot.position
+        }
         self.emit_event(
             'arrived_at_fort',
-            formatted='Arrived at fort.'
+            formatted='Arrived at fort.',
+            data=arrived_at_fort_data
         )
         return WorkerResult.SUCCESS
 

--- a/pokemongo_bot/cell_workers/pokemon_catch_worker.py
+++ b/pokemongo_bot/cell_workers/pokemon_catch_worker.py
@@ -191,30 +191,6 @@ class PokemonCatchWorker(BaseTask):
             return True
         return self._pokemon_matches_config(self.config.vips, pokemon, default_logic='or')
 
-    def _get_current_pokemon_ids(self):
-        # don't use cached bot.get_inventory() here because we need to have actual information in capture logic
-        response_dict = self.api.get_inventory()
-
-        try:
-            inventory_items = response_dict['responses']['GET_INVENTORY']['inventory_delta']['inventory_items']
-        except KeyError:
-            return []  # no items
-
-        id_list = []
-        for item in inventory_items:
-            try:
-                pokemon = item['inventory_item_data']['pokemon_data']
-            except KeyError:
-                continue
-
-            # ignore eggs
-            if pokemon.get('is_egg'):
-                continue
-
-            id_list.append(pokemon['id'])
-
-        return id_list
-
     def _pct(self, rate_by_ball):
         return '{0:.2f}'.format(rate_by_ball * 100)
 
@@ -326,9 +302,6 @@ class PokemonCatchWorker(BaseTask):
                 catch_rate_by_ball = self._use_berry(berry_id, berry_count, encounter_id, catch_rate_by_ball, current_ball)
                 berry_count -= 1
 
-            # get current pokemon list before catch
-            pokemon_before_catch = self._get_current_pokemon_ids()
-
             # try to catch pokemon!
             items_stock[current_ball] -= 1
             self.emit_event(
@@ -418,31 +391,4 @@ class PokemonCatchWorker(BaseTask):
 
                 self.bot.softban = False
 
-                # evolve pokemon if necessary
-                if self.config.evolve_captured and (self.config.evolve_captured[0] == 'all' or pokemon.name in self.config.evolve_captured):
-                    pokemon_after_catch = self._get_current_pokemon_ids()
-                    pokemon_to_evolve = list(set(pokemon_after_catch) - set(pokemon_before_catch))
-
-                    if len(pokemon_to_evolve) == 0:
-                        break
-
-                    self._do_evolve(pokemon, pokemon_to_evolve[0])
-
             break
-
-    def _do_evolve(self, pokemon, new_pokemon_id):
-        response_dict = self.api.evolve_pokemon(pokemon_id=new_pokemon_id)
-        catch_pokemon_status = response_dict['responses']['EVOLVE_POKEMON']['result']
-
-        if catch_pokemon_status == 1:
-            self.emit_event(
-                'pokemon_evolved',
-                formatted='{pokemon} evolved!',
-                data={'pokemon': pokemon.name}
-            )
-        else:
-            self.emit_event(
-                'pokemon_evolve_fail',
-                formatted='Failed to evolve {pokemon}!',
-                data={'pokemon': pokemon.name}
-            )

--- a/pokemongo_bot/cell_workers/update_live_stats.py
+++ b/pokemongo_bot/cell_workers/update_live_stats.py
@@ -6,27 +6,17 @@ from pokemongo_bot.base_task import BaseTask
 from pokemongo_bot.worker_result import WorkerResult
 from pokemongo_bot.tree_config_builder import ConfigException
 
-class UpdateTitleStats(BaseTask):
+
+class UpdateLiveStats(BaseTask):
     """
-    Periodically updates the terminal title to display stats about the bot.
+    Periodically displays stats about the bot in the terminal and/or in its title.
 
     Fetching some stats requires making API calls. If you're concerned about the amount of calls
     your bot is making, don't enable this worker.
 
     Example config :
     {
-        "type": "UpdateTitleStats",
-        "config": {
-            "min_interval": 10,
-            "stats": ["login", "uptime", "km_walked", "level_stats", "xp_earned", "xp_per_hour"],
-        }
-    }
-
-    You can set a logging on terminal mode like this:
-
-    Example logging on console (and disabling title change):
-    {
-        "type": "UpdateTitleStats",
+        "type": "UpdateLiveStats",
         "config": {
             "min_interval": 10,
             "stats": ["login", "uptime", "km_walked", "level_stats", "xp_earned", "xp_per_hour"],
@@ -34,6 +24,15 @@ class UpdateTitleStats(BaseTask):
             "terminal_title": false
         }
     }
+
+    min_interval : The minimum interval at which the stats are displayed,
+                   in seconds (defaults to 120 seconds).
+                   The update interval cannot be accurate as workers run synchronously.
+    stats : An array of stats to display and their display order (implicitly),
+            see available stats below (defaults to []).
+    terminal_log : Logs the stats into the terminal (defaults to false).
+    terminal_title : Displays the stats into the terminal title (defaults to true).
+
     Available stats :
     - login : The account login (from the credentials).
     - username : The trainer name (asked at first in-game connection).
@@ -48,6 +47,7 @@ class UpdateTitleStats(BaseTask):
     - stops_visited : The number of visited stops.
     - pokemon_encountered : The number of encountered pokemon.
     - pokemon_caught : The number of caught pokemon.
+    - captures_per_hour : The estimated number of pokemon captured per hour.
     - pokemon_released : The number of released pokemon.
     - pokemon_evolved : The number of evolved pokemon.
     - pokemon_unseen : The number of pokemon never seen before.
@@ -56,15 +56,8 @@ class UpdateTitleStats(BaseTask):
     - stardust_earned : The number of earned stardust since the bot started.
     - highest_cp_pokemon : The caught pokemon with the highest CP since the bot started.
     - most_perfect_pokemon : The most perfect caught pokemon since the bot started.
-
-    min_interval : The minimum interval at which the title is updated,
-                   in seconds (defaults to 10 seconds).
-                   The update interval cannot be accurate as workers run synchronously.
-    stats : An array of stats to display and their display order (implicitly),
-            see available stats above.
     """
     SUPPORTED_TASK_API_VERSION = 1
-
 
     def __init__(self, bot, config):
         """
@@ -74,62 +67,78 @@ class UpdateTitleStats(BaseTask):
         :param config: The task configuration.
         :type config: dict
         """
-        super(UpdateTitleStats, self).__init__(bot, config)
+        super(UpdateLiveStats, self).__init__(bot, config)
 
         self.next_update = None
 
         self.min_interval = int(self.config.get('min_interval', 120))
         self.displayed_stats = self.config.get('stats', [])
-        self.terminal_log = self.config.get('terminal_log', False)
-        self.terminal_title = self.config.get('terminal_title', True)
+        self.terminal_log = bool(self.config.get('terminal_log', False))
+        self.terminal_title = bool(self.config.get('terminal_title', True))
 
-        self.bot.event_manager.register_event('update_title', parameters=('title',))
-        self.bot.event_manager.register_event('log_stats',parameters=('title',))
+        self.bot.event_manager.register_event('log_stats', parameters=('stats',))
 
     def initialize(self):
         pass
 
     def work(self):
         """
-        Updates the title if necessary.
+        Displays the stats if necessary.
         :return: Always returns WorkerResult.SUCCESS.
         :rtype: WorkerResult
         """
         if not self._should_display():
             return WorkerResult.SUCCESS
-        title = self._get_stats_title(self._get_player_stats())
-        # If title is empty, it couldn't be generated.
-        if not title:
+        line = self._get_stats_line(self._get_player_stats())
+        # If line is empty, it couldn't be generated.
+        if not line:
             return WorkerResult.SUCCESS
 
         if self.terminal_title:
-            self._update_title(title, _platform)
+            self._update_title(line, _platform)
 
         if self.terminal_log:
-            self._log_on_terminal(title)
+            self._log_on_terminal(line)
         return WorkerResult.SUCCESS
 
     def _should_display(self):
         """
-        Returns a value indicating whether the title should be updated.
-        :return: True if the title should be updated; otherwise, False.
+        Returns a value indicating whether the stats should be displayed.
+        :return: True if the stats should be displayed; otherwise, False.
         :rtype: bool
         """
+        if not self.terminal_title and not self.terminal_log:
+            return False
         return self.next_update is None or datetime.now() >= self.next_update
 
-    def _log_on_terminal(self, title):
+    def _compute_next_update(self):
+        """
+        Computes the next update datetime based on the minimum update interval.
+        :return: Nothing.
+        :rtype: None
+        """
+        self.next_update = datetime.now() + timedelta(seconds=self.min_interval)
+
+    def _log_on_terminal(self, stats):
+        """
+        Logs the stats into the terminal using an event.
+        :param stats: The stats to display.
+        :type stats: string
+        :return: Nothing.
+        :rtype: None
+        """
         self.emit_event(
             'log_stats',
-            formatted="{title}",
+            formatted="{stats}",
             data={
-                'title': title
+                'stats': stats
             }
         )
-        self.next_update = datetime.now() + timedelta(seconds=self.min_interval)
+        self._compute_next_update()
 
     def _update_title(self, title, platform):
         """
-        Updates the window title using different methods, according to the given platform
+        Updates the window title using different methods, according to the given platform.
         :param title: The new window title.
         :type title: string
         :param platform: The platform string.
@@ -139,14 +148,6 @@ class UpdateTitleStats(BaseTask):
         :raise: RuntimeError: When the given platform isn't supported.
         """
 
-        self.emit_event(
-            'update_title',
-            formatted="{title}",
-            data={
-                'title': title
-            }
-        )
-
         if platform == "linux" or platform == "linux2" or platform == "cygwin":
             stdout.write("\x1b]2;{}\x07".format(title))
             stdout.flush()
@@ -154,14 +155,12 @@ class UpdateTitleStats(BaseTask):
             stdout.write("\033]0;{}\007".format(title))
             stdout.flush()
         elif platform == "win32":
-            ctypes.windll.kernel32.SetConsoleTitleA(title)
+            ctypes.windll.kernel32.SetConsoleTitleA(title.encode())
         else:
             raise RuntimeError("unsupported platform '{}'".format(platform))
+        self._compute_next_update()
 
-        self.next_update = datetime.now() + timedelta(seconds=self.min_interval)
-
-
-    def _get_stats_title(self, player_stats):
+    def _get_stats_line(self, player_stats):
         """
         Generates a stats string with the given player stats according to the configuration.
         :return: A string containing human-readable stats, ready to be displayed.
@@ -194,6 +193,7 @@ class UpdateTitleStats(BaseTask):
         stops_visited = metrics.visits['latest'] - metrics.visits['start']
         pokemon_encountered = metrics.num_encounters()
         pokemon_caught = metrics.num_captures()
+        captures_per_hour = int(metrics.captures_per_hour())
         pokemon_released = metrics.releases
         pokemon_evolved = metrics.num_evolutions()
         pokemon_unseen = metrics.num_new_mons()
@@ -223,6 +223,7 @@ class UpdateTitleStats(BaseTask):
             'stops_visited': 'Visited {:,} stops'.format(stops_visited),
             'pokemon_encountered': 'Encountered {:,} pokemon'.format(pokemon_encountered),
             'pokemon_caught': 'Caught {:,} pokemon'.format(pokemon_caught),
+            'captures_per_hour': '{:,} pokemon/h'.format(captures_per_hour),
             'pokemon_released': 'Released {:,} pokemon'.format(pokemon_released),
             'pokemon_evolved': 'Evolved {:,} pokemon'.format(pokemon_evolved),
             'pokemon_unseen': 'Encountered {} new pokemon'.format(pokemon_unseen),
@@ -251,9 +252,9 @@ class UpdateTitleStats(BaseTask):
             return available_stats[stat]
 
         # Map stats the user wants to see to available stats and join them with pipes.
-        title = ' | '.join(map(get_stat, self.displayed_stats))
+        line = ' | '.join(map(get_stat, self.displayed_stats))
 
-        return title
+        return line
 
     def _get_player_stats(self):
         """

--- a/pokemongo_bot/event_handlers/colored_logging_handler.py
+++ b/pokemongo_bot/event_handlers/colored_logging_handler.py
@@ -71,7 +71,6 @@ class ColoredLoggingHandler(EventHandler):
         'moving_to_fort':                       'white',
         'moving_to_lured_fort':                 'white',
         'pokemon_catch_rate':                   'white',
-        'pokemon_evolve_fail':                  'white',
         'pokestop_on_cooldown':                 'white',
         'pokestop_out_of_range':                'white',
         'polyline_request':                     'white',

--- a/pokemongo_bot/metrics.py
+++ b/pokemongo_bot/metrics.py
@@ -42,6 +42,14 @@ class Metrics(object):
     def num_captures(self):
         return self.captures['latest'] - self.captures['start']
 
+    def captures_per_hour(self):
+        """
+        Returns an estimated number of pokemon caught per hour.
+        :return: An estimated number of pokemon caught per hour.
+        :rtype: float
+        """
+        return self.num_captures() / (time.time() - self.start_time) * 3600
+
     def num_visits(self):
         return self.visits['latest'] - self.visits['start']
 

--- a/setup.sh
+++ b/setup.sh
@@ -37,7 +37,7 @@ Input location
 " location
 read -p "Input gmapkey 
 " gmapkey
-cp -f configs/config.json.example configs/config.json && chmod 755
+cp -f configs/config.json.example configs/config.json && chmod 755 configs/config.json
 if [ "$auth" = "2" ]
 then
 sed -i "s/google/ptc/g" configs/config.json
@@ -109,8 +109,10 @@ Pokebotreset
 Pokebotupdate
 ;;
 --backup|-b)
-mkdir $backuppath
+mkdir -p $backuppath
 cp -f $pokebotpath/configs/config*.json $backuppath/
+cp -f $pokebotpath/configs/*.gpx $backuppath/
+cp -f $pokebotpath/configs/path*.json $backuppath/
 cp -f $pokebotpath/web/config/userdata.js $backuppath/
 echo "Backup complete"
 ;;

--- a/tests/update_live_stats_test.py
+++ b/tests/update_live_stats_test.py
@@ -2,18 +2,20 @@ import unittest
 from sys import platform as _platform
 from datetime import datetime, timedelta
 from mock import call, patch, MagicMock
-from pokemongo_bot.cell_workers.update_title_stats import UpdateTitleStats
+from pokemongo_bot.cell_workers.update_live_stats import UpdateLiveStats
 from tests import FakeBot
 
 
-class UpdateTitleStatsTestCase(unittest.TestCase):
+class UpdateLiveStatsTestCase(unittest.TestCase):
     config = {
         'min_interval': 20,
         'stats': ['login', 'username', 'pokemon_evolved', 'pokemon_encountered', 'uptime',
                   'pokemon_caught', 'stops_visited', 'km_walked', 'level', 'stardust_earned',
                   'level_completion', 'xp_per_hour', 'pokeballs_thrown', 'highest_cp_pokemon',
                   'level_stats', 'xp_earned', 'pokemon_unseen', 'most_perfect_pokemon',
-                  'pokemon_stats', 'pokemon_released']
+                  'pokemon_stats', 'pokemon_released', 'captures_per_hour'],
+        'terminal_log': True,
+        'terminal_title': False
     }
     player_stats = {
         'level': 25,
@@ -26,7 +28,7 @@ class UpdateTitleStatsTestCase(unittest.TestCase):
         self.bot = FakeBot()
         self.bot._player = {'username': 'Username'}
         self.bot.config.username = 'Login'
-        self.worker = UpdateTitleStats(self.bot, self.config)
+        self.worker = UpdateLiveStats(self.bot, self.config)
 
     def mock_metrics(self):
         self.bot.metrics = MagicMock()
@@ -37,6 +39,7 @@ class UpdateTitleStatsTestCase(unittest.TestCase):
         self.bot.metrics.visits = {'latest': 250, 'start': 30}
         self.bot.metrics.num_encounters.return_value = 130
         self.bot.metrics.num_captures.return_value = 120
+        self.bot.metrics.captures_per_hour.return_value = 75
         self.bot.metrics.releases = 30
         self.bot.metrics.num_evolutions.return_value = 12
         self.bot.metrics.num_new_mons.return_value = 3
@@ -45,16 +48,30 @@ class UpdateTitleStatsTestCase(unittest.TestCase):
         self.bot.metrics.highest_cp = {'desc': 'highest_cp'}
         self.bot.metrics.most_perfect = {'desc': 'most_perfect'}
 
-    def test_process_config(self):
+    def test_config(self):
         self.assertEqual(self.worker.min_interval, self.config['min_interval'])
         self.assertEqual(self.worker.displayed_stats, self.config['stats'])
+        self.assertEqual(self.worker.terminal_title, self.config['terminal_title'])
+        self.assertEqual(self.worker.terminal_log, self.config['terminal_log'])
 
     def test_should_display_no_next_update(self):
         self.worker.next_update = None
 
         self.assertTrue(self.worker._should_display())
 
-    @patch('pokemongo_bot.cell_workers.update_title_stats.datetime')
+    @patch('pokemongo_bot.cell_workers.update_live_stats.datetime')
+    def test_should_display_no_terminal_log_title(self, mock_datetime):
+        # _should_display should return False if both terminal_title and terminal_log are false
+        # in configuration, even if we're past next_update.
+        now = datetime.now()
+        mock_datetime.now.return_value = now + timedelta(seconds=20)
+        self.worker.next_update = now
+        self.worker.terminal_log = False
+        self.worker.terminal_title = False
+
+        self.assertFalse(self.worker._should_display())
+
+    @patch('pokemongo_bot.cell_workers.update_live_stats.datetime')
     def test_should_display_before_next_update(self, mock_datetime):
         now = datetime.now()
         mock_datetime.now.return_value = now - timedelta(seconds=20)
@@ -62,7 +79,7 @@ class UpdateTitleStatsTestCase(unittest.TestCase):
 
         self.assertFalse(self.worker._should_display())
 
-    @patch('pokemongo_bot.cell_workers.update_title_stats.datetime')
+    @patch('pokemongo_bot.cell_workers.update_live_stats.datetime')
     def test_should_display_after_next_update(self, mock_datetime):
         now = datetime.now()
         mock_datetime.now.return_value = now + timedelta(seconds=20)
@@ -70,7 +87,7 @@ class UpdateTitleStatsTestCase(unittest.TestCase):
 
         self.assertTrue(self.worker._should_display())
 
-    @patch('pokemongo_bot.cell_workers.update_title_stats.datetime')
+    @patch('pokemongo_bot.cell_workers.update_live_stats.datetime')
     def test_should_display_exactly_next_update(self, mock_datetime):
         now = datetime.now()
         mock_datetime.now.return_value = now
@@ -78,65 +95,83 @@ class UpdateTitleStatsTestCase(unittest.TestCase):
 
         self.assertTrue(self.worker._should_display())
 
-    @patch('pokemongo_bot.cell_workers.update_title_stats.datetime')
-    def test_next_update_after_update_title(self, mock_datetime):
+    @patch('pokemongo_bot.cell_workers.update_live_stats.datetime')
+    def test_compute_next_update(self, mock_datetime):
         now = datetime.now()
         mock_datetime.now.return_value = now
         old_next_display_value = self.worker.next_update
-        self.worker._update_title('', 'linux2')
+        self.worker._compute_next_update()
 
         self.assertNotEqual(self.worker.next_update, old_next_display_value)
         self.assertEqual(self.worker.next_update,
                          now + timedelta(seconds=self.config['min_interval']))
 
-    @patch('pokemongo_bot.cell_workers.update_title_stats.stdout')
-    def test_update_title_linux_cygwin(self, mock_stdout):
+    @patch('pokemongo_bot.cell_workers.update_live_stats.stdout')
+    @patch('pokemongo_bot.cell_workers.UpdateLiveStats._compute_next_update')
+    def test_update_title_linux_cygwin(self, mock_compute_next_update, mock_stdout):
         self.worker._update_title('new title linux', 'linux')
 
         self.assertEqual(mock_stdout.write.call_count, 1)
         self.assertEqual(mock_stdout.write.call_args, call('\x1b]2;new title linux\x07'))
+        self.assertEqual(mock_compute_next_update.call_count, 1)
 
         self.worker._update_title('new title linux2', 'linux2')
 
         self.assertEqual(mock_stdout.write.call_count, 2)
         self.assertEqual(mock_stdout.write.call_args, call('\x1b]2;new title linux2\x07'))
+        self.assertEqual(mock_compute_next_update.call_count, 2)
 
         self.worker._update_title('new title cygwin', 'cygwin')
 
         self.assertEqual(mock_stdout.write.call_count, 3)
         self.assertEqual(mock_stdout.write.call_args, call('\x1b]2;new title cygwin\x07'))
+        self.assertEqual(mock_compute_next_update.call_count, 3)
 
-    @patch('pokemongo_bot.cell_workers.update_title_stats.stdout')
-    def test_update_title_darwin(self, mock_stdout):
+    @patch('pokemongo_bot.cell_workers.update_live_stats.stdout')
+    @patch('pokemongo_bot.cell_workers.UpdateLiveStats._compute_next_update')
+    def test_update_title_darwin(self, mock_compute_next_update, mock_stdout):
         self.worker._update_title('new title darwin', 'darwin')
 
         self.assertEqual(mock_stdout.write.call_count, 1)
         self.assertEqual(mock_stdout.write.call_args, call('\033]0;new title darwin\007'))
+        self.assertEqual(mock_compute_next_update.call_count, 1)
 
     @unittest.skipUnless(_platform.startswith("win"), "requires Windows")
-    @patch('pokemongo_bot.cell_workers.update_title_stats.ctypes')
-    def test_update_title_win32(self, mock_ctypes):
+    @patch('pokemongo_bot.cell_workers.update_live_stats.ctypes')
+    @patch('pokemongo_bot.cell_workers.UpdateLiveStats._compute_next_update')
+    def test_update_title_win32(self, mock_compute_next_update, mock_ctypes):
         self.worker._update_title('new title win32', 'win32')
 
         self.assertEqual(mock_ctypes.windll.kernel32.SetConsoleTitleA.call_count, 1)
         self.assertEqual(mock_ctypes.windll.kernel32.SetConsoleTitleA.call_args,
                          call('new title win32'))
+        self.assertEqual(mock_compute_next_update.call_count, 1)
 
-    def test_get_stats_title_player_stats_none(self):
-        title = self.worker._get_stats_title(None)
+    @patch('pokemongo_bot.cell_workers.update_live_stats.BaseTask.emit_event')
+    @patch('pokemongo_bot.cell_workers.UpdateLiveStats._compute_next_update')
+    def test_log_on_terminal(self, mock_compute_next_update, mock_emit_event):
+        self.worker._log_on_terminal('stats')
 
-        self.assertEqual(title, '')
+        self.assertEqual(mock_emit_event.call_count, 1)
+        self.assertEqual(mock_emit_event.call_args,
+                         call('log_stats', data={'stats': 'stats'}, formatted='{stats}'))
+        self.assertEqual(mock_compute_next_update.call_count, 1)
 
-    def test_get_stats_no_displayed_stats(self):
+    def test_get_stats_line_player_stats_none(self):
+        line = self.worker._get_stats_line(None)
+
+        self.assertEqual(line, '')
+
+    def test_get_stats_line_no_displayed_stats(self):
         self.worker.displayed_stats = []
-        title = self.worker._get_stats_title(self.player_stats)
+        line = self.worker._get_stats_line(self.player_stats)
 
-        self.assertEqual(title, '')
+        self.assertEqual(line, '')
 
-    def test_get_stats(self):
+    def test_get_stats_line(self):
         self.mock_metrics()
 
-        title = self.worker._get_stats_title(self.player_stats)
+        line = self.worker._get_stats_line(self.player_stats)
         expected = 'Login | Username | Evolved 12 pokemon | Encountered 130 pokemon | ' \
                    'Uptime : 15:42:13 | Caught 120 pokemon | Visited 220 stops | ' \
                    '42.05km walked | Level 25 | Earned 24,069 Stardust | ' \
@@ -145,6 +180,6 @@ class UpdateTitleStatsTestCase(unittest.TestCase):
                    '+424,242 XP | Encountered 3 new pokemon | ' \
                    'Most perfect pokemon : most_perfect | ' \
                    'Encountered 130 pokemon, 120 caught, 30 released, 12 evolved, ' \
-                   '3 never seen before | Released 30 pokemon'
+                   '3 never seen before | Released 30 pokemon | 75 pokemon/h'
 
-        self.assertEqual(title, expected)
+        self.assertEqual(line, expected)


### PR DESCRIPTION
# Please Note (you may remove this section before opening your PR):
We receive lots of PRs and it is hard to give proper review to PRs. Please make it easy on us by following these guidelines:

1. We do not accept changes to `master`. Please make sure your pull request is aimed at `dev`.
2. If you changed a bunch of files (that aren't config files) or multiple workers to implement your feature, it probably won't get proper attention. Please split it up into multiple, smaller, more focused, and iterative PRs if you can.
3. If you are adding a config value to something, make sure you update the appropriate `config.json` example files.


## Short Description:

## Fixes (provide links to github issues if you can):
-
-
-


* Adding plugin support (#2679)

* Adding plugin support

* Adding an empty __init__.py

* Moving the base task to the project root (#2702)

* Moving the base task to the project root

* Moving the base class more

* Changing the import again

* Adding a heartbeat to the analytics (#2709)

* Adding a heartbeat to the analytics

* Heartbeat every 30 seconds, not every 5

* Don't double track clients

* Fix 'local variable 'bot' referenced before assignment'

* Providing an error if tasks don't work for the given api (#2732)

* Fix for utf8 encoding when catching lured pokemon (#2720)

* Fixing lure pokestop encoding

* fixing lure encoding

* Fix For catchable not being displayed on the web (#2719)

* Fix For catchable not being displayed on the web

* Update catch_visible_pokemon.py

* Added encrypt.so compilation process to Dockerfile (#2695)

* OS Detection for encrypt lib (#2768)

Fix 32bit check, darwin and linux use the same file

Make it a function

Check if file exists, if not show error

Define file_name first

Fix return

Check if file exists, if not show error

Print info about paths

Fix for 32/64bit detection

* Fix Typo in unexpected_response_retry (#2531)

fixes #2525 #2523

* Revert "changing license from MIT to GPLv3"

This reverts commit 69fb64f2bf7c12e28c2bb6d2b636c6af55822448.

* When the google analytics domain is blocked the bot crashed. (#2764)

With a simple try / except this can be solved.

Fix dirty catch all

* Fixes #2698 - Prevents "Possibly searching too often" error after re-login. (#2771)

* Fixes #2698
- Added api.activate_signature call to prevent issue after re-login.
- Also replaced deprecated log call with event_manager emit to prevent exception being thrown.

* Modified to use OS detected library path as per PR #2768

* Support loading plugins from .zip files (#2766)

* Keep track of how many pokemon released (#2884)

* Setting Library path to work with encrypt.so (#2899)

Setting LD_LIBRARY_PATH on Dockerfile

* :sparkles: Added login and username to available stats (#2494)

Added a player_data property in PokemonGoBot to access player data from outside
Added unit tests for login and username stats
Added tests for call args when updating the window title
Added a platform-specific test for window title updating on win32 platform

* [dev] small fixes (#2912)

* Fixed emit_event typo

* Update CONTRIBUTORS.md

* Changed initialization location for "bot"

We use bot in main exception on 128

* Update pokecli.py

* Rename load_path to load_plugin (#2947)

* Adding some logic for pulling plugins from github (#2967)

* flush after title update (#2977)

* correctly re-raise exception to keep backtrace (#2944)

* Update MoveToMapPokemon to use events instead of logger. (#2913)

* Config/encrypt.so (#2964)

* Add config option for libencrypt.so

* Correctly set the config value and check for the file in said dir

* Fixed mispelling for "formatted" variable (#2984)

* Loading plugins from Github (#2992)

* Checking github plugin file existence

* Loading plugins from github

* Fixed #3000 (#3003)

Fixed syntax error on "move_to_map_pokemon.py" that makes the client crash when using this feature.

* Added MaxPotion inventory count to summary. (#3015)

Short Description: 
The Max Potion count was missing from the inventory summary.

Was #2456

* Added cleanup of download and files for encrypt.so after they are no longer needed (#3011)

* Fix bot not returning back after telepoting (#3014)

* Fix typo: last_long -> last_lon

* Whitespace cleanup

* Fix bug introduced by #3037: bot not returning back

* Fix Dockerfile installation (#3057)

* Fix for #3045 (#3055)

* Added request to check configuration (#3089)

* Fixed Dockerfile - missing \ on command lines (#3096)

* Fixed mispelling for "formatted" variable

* Docker commands missing trailing \

* Fix for FileIO slowing bot performance.This puts the map writing into a thread and makes sure it only executes  once. (#3100)

* Change word usage: "fled" to "escaped" (#3118)

"fled" is confusing to lot of people and is easily confused with pokemon vanishing. "escaped" is a better term.

* Update the example config file (#3120)

* Add config option for libencrypt.so

* Add config option for libencrypt.so

* Add config option for libencrypt.so

* Add config option for libencrypt.so

* Rename path.example.json to path.json.example

* typo: logrmation -> information (#2601)

Fix a typo. 

I assume that it was "information" initially, but became "logrmation" when someone used replace all functionality to replace all infos with logs. But I might be totally wrong at this point, idk. Just didn't like the word and wanted to fix that typo.

* Change fled to escaped (#3129)

Fix an issue after PR #3118

* When JSON parsing fails, give a rough indication of why (#3137)

* When JSON parsing fails, give a rough indication of why

* Use the official package instead of SHA1 commit

* Handle Github Download Zip Format (#3108)

* Checking github plugin file existence

* Loading plugins from github

* Starting install code for github plugins

* Updating GithubPlugin to support extracting folders

* Handling github zip formats by extracting to the correct location

* Refactor catch worker (#2527)

* refactor catch worker

* fix

* few renames

* add to contributors

* fix

* add missing behavior

* fix encounter events

* don't make events about ignored pokemon

* Added Run-Loop (#3143)

* Add files via upload

modified run script wich let you run the boot in a loop(if it crashes it restarts)

* Integreated Loop into run.sh

modified run.sh to loop the script so that even if it crashes it
automaticly restarts.

* fixing loop in spin fort task (#3165)

* Some love for the vim users (#3154)

* Updated README with link to desktop version (#3208)

* Fix for #3190 (#3197)

* MoveToMap: Add minimum balls to run (#3166)

* added config to ignore item count for Spin and MoveToFort (#3160)

* [Inventory Management] Add a central class for caching/parsing inventory & static data (#2528)

* new class to centralize inventory management

* use new inventory class in evolve_pokemon

* use new inventory to display # candy after catch

* Keeping a cache of gym information (#3236)

* New Option: "dont_nickname_favorite" (#2496)

* New Option: "dont_nickname_favorite"

This change (line 19) adds the option, that the user can choose, whether their favorite pokemons should also get a new nickname or not.

If a user want this, then he or she has to add the line ("dont_nickname_favorite" = true) after ("nickname_template": " ... ",).

* Update nickname_pokemon.py

* Update

* Put change to line 30

This reduce the reduce the runtime, because favorite pokemon won't be added to the list.

* Restart the loop when catching pokemon and there are more to catch (#3242)

* fixed NameError: global name 'pokemon_name' is not defined (#3244)

resolves ```traceback (most recent call last):
  File "pokecli.py", line 521, in <module>
    main()
  File "pokecli.py", line 95, in main
    bot.tick()
  File "/usr/src/app/pokemongo_bot/__init__.py", line 451, in tick
    if worker.work() == WorkerResult.RUNNING:
  File "/usr/src/app/pokemongo_bot/cell_workers/evolve_pokemon.py", line 38, in work
    self._execute_pokemon_evolve(pokemon, cache)
  File "/usr/src/app/pokemongo_bot/cell_workers/evolve_pokemon.py", line 117, in _execute_pokemon_evolve
    cache[pokemon.name] = 1
NameError: global name 'pokemon_name' is not defined```

* Stop fetching gym details (#3245)

* Checking all forts for lured pokemon (#3163)

* Fix flooding of keep_best_release (#3223)

* Fix flooding of keep_best_release

* Fix flooding of keep_best_release

* [Feature] Recycle Threshold (#2465)

* Add Threshold Option

* Add Threshold Option to Example Configs

* Add Name to Contributors

* Change config name and message

* Remove logger

* Add option to run when storage less than something

* Change Message

* Fix

* Error fixes, message improvement

* Config Changes and Remove Option

* Call heartbeat on step_walker even if speed is higher than distance (#2513)

* Return an empty list if no pokemon are available. (#3259)

The changes introduced in 4c95259 expose this bug.

* Allow UpdateTitleStats to emit events instead of rewriting the console (#3264)

* Updating our issue and PR templates to be more helpful (#3262)

* Dev (#3277)

* * adding enhanced sniping capabilities for move_to_map_pokemon

* Adding enhanced sniping capabilities for move_to_map_pokemon

* Update pgoapi to a newer version (#3241)

This should hopefully fix issues like #3181, #3098, #2874 and
potentially more.

Needs testing/verification. I am running now, but it does take about an
hour to trigger.

* Fix unexpected egg incubation retry (#3276)

incubator['used'] flag is set but not used in IncubateEggs._apply_incubators

* has_next_evolution is a function not a property (#3284)

* Powerful setup.sh (#3263)

* Rewrite run.sh

Very powerful run.sh with lots of function.
1.install(make .so)
2.update
3.config generator
4.config backup
5.run loop make it never down

It should run like 
run.sh *.json or other opinion. 
See -help.

* Update run.sh

* Update run.sh

OK problem solved

* Delete setup.py

* Rename run.sh to setup.sh

* Create run.sh

* Update setup.sh

* Update install.sh

* Update setup.sh

* Update run.sh

* Update setup.sh

Some small fix.

* Added +x to run.sh

* Added a configuration option "path_startmode" (conflict merge #2489) (#3270)

* Upstream update and merge, with path_startmode configuration

* Removed logger and fixed base task path

* As per request, path_startmode is now path_start_mode

* Removed all logging

* Adding documentation for how to use and write plugins (#3254)

* Adding documentation for how to use and write plugins

* Adding a link to the plugins docs in the Readme

* Updating link to the plugin docs in the readme

* Checking config file exists in run.sh (#3326)

* Improve and update pokemon.json (#3331)

1. Unminify for simplier edits
2. Add BaseAttack, BaseDefense, BaseStamina, CaptureRate, FleeRate, Fast/Special Attack(s)

* Made paths to .json files absolute so pokecli.py can be called from CRON (#3157)

* Made paths to .json files absolute so pokecli.py can be called from CRON

* made file paths abs in inventory

fixed incorrect dict reference, changed to .get() as felt this was intended

* Add fast & charged moves data from #2117 (originally by @iananass) (#3336)

Data for pokemon quick & slow attacks

* Upgrade pgoapi to the b4bf0e089dfe09903f8dda37dae56910e01f94cc commit(latest for now). (#3337)

* Revert "Upgrade pgoapi to the b4bf0e089dfe09903f8dda37dae56910e01f94cc commit…" (#3340)

* Added map_path configuration for move_to_map. (#3339)

* Log stats on terminal (#3312)

* added _log_on_terminal function

* Added logic to toggle terminal logging functionality from config file

* Added possibility to disable title changes, refactor code

* Refactor tuples

* Refactor ifs to clearer syntax

* changes to improve event system based on new web ui devs requests

* typo :D

* let's use dict.get a bit to avoid errors

* keeping the account in the remote command response

* Add ColoredLoggingHandler (#3198)

* Update TransferPokemon to use new Inventory Class (#3320)

* Update TransferPokemon to use new Inventory Class

* Use base_dir

* Don't release pokemon if bot is on test mode

* Some text fixes for setup.sh (#3390)

Minor text fix.

* Fix path of shells in install.sh (#3393)

* Update install.sh

Fix path

* Update setup.sh

fix path

* Update run.sh

fix path

* Fix evolution error in pokemon.json (#3344)

Fix evolution error in pokemon.json

* Improve formatting consistency in transfer_pokemon.py (#3397)

Improve formatting consistency

* Remove unnecessary file

* Put info on the next line in run.sh (#3422)

* Update setup.sh

fix typo

* Update run.sh

fix typo

* Fix Struct() argument 1 must be string, not unicode. (#3375)

* Give the possibility to disable a task without removing it (#3417)

* Give the possiblity to disable a task in config without removing it from the config file

* Put exmple only in nickname task

* Add Unit testing

* typo

* Use enabled false as exemple

* fix config creation (#3482)

Changed auth to be more specifik and added right permissions.

* Remove unused IV calculation from evolve_pokemon (#3487)

Previously IV was computed in each worker. Now its fetched from inventory. This was left over and not called in the worker at all.

* Don't show Inventory full event if we set "ignore_item_count" (#3440)

* Fix showing the date in run.sh (#3433)

fix the logic of showing the date

* Typo fix: show new catch rate after berry throw. (#3521)

* Fix stdout is not a terminal (#3511)

* Ensure recycling happens if bag is over capacity. (#3531)

Short Description:
Ensures you that item Recycling happens if you have more items than the total bag capacity.

When you level up, you are awarded items which can cause the bag to be over the capacity.

* Better inventory:  attacks & movesets,  IV CP perfection,  pokemon level,  etc.. (#3455)

* Add "level to CP multiplier" data

Data is from justinleewells/pogo-optimizer:
https://github.com/justinleewells/pogo-optimizer/blob/edd692d/data/game/level-to-cpm.json

* Many improvements & additions for the inventory logic

 - LevelToCPm, FastAttacks, ChargedAttacks, Movesets
 - More info for each pokemon:  attacks data,  percent to max cp,  IV CP perfection

* Add PyCharm/IDEA *.iml (project file) to ignored

* Fixes, improvements & refactoring for inventory.py

 - Return inadvertently deleted pieces of code (thanks to @achretien)
 - Evolution logic fixes
 - Other minor fixes
 - Moveset logic moved to Moveset class

* Fix data for pokemons & charged moves

* Inventory tests:  pokemon data,  LevelToCPm,  attacks

* Fix travis build

* Fix info for Hitmonlee & Hitmonchan

* Revert "Better inventory:  attacks & movesets,  IV CP perfection,  pokemon level,  etc.." (#3549)

* run.bat for windows (#3542)

run.bat with persistent loop

* Fix error when MoveToFort called from handle_soft_ban.py (#3500)

* Fix error when MoveToFort called from handle_soft_ban.py

* Added myself to CONTRIBUTORS.md

* Fixed list of charged attacks for Venonat (#3548) + BaseDefense/BaseStamina info fix (#3550)

* Revert "Revert "Better inventory:  attacks & movesets,  IV CP perfection,  pokemon level,  etc.." (#3549)"

This reverts commit e9b229ec0fd14a4814ea7431b1256850e907cfbf.

* Fix BaseDefense/BaseStamina and type info

Fixed BaseDefense/BaseStamina info (was mixed up)
Fixed type info for Mr. Mime, Clefairy, Clefable, Jigglypuff, Wigglytuff
Added check for correctness of exact CP value calculation

* Fixed list of charged attacks for Venonat

* Don't kill bot in case of unexpected moveset, use fallback + better error message

* Blacklisting tejado from getting mentioned by the mention-bot

* Moving wiki pages to docs folder

* UpdateTitleStats -> UpdateLiveStats, new stat, refactoring (#3467)

* Renamed UpdateTitleStats to UpdateLiveStats

* Cleaned worker documentation
* Added documentation for terminal_log and terminal_title
* Fixed https://github.com/PokemonGoF/PokemonGo-Bot/pull/3312#issuecomment-238672978
* Made some refactoring
* Added captures_per_hour stat that shows estimated pokemon captures per hour
* Added a captures_per_hour method in metrics.py
* Added unit tests for features added in https://github.com/PokemonGoF/PokemonGo-Bot/pull/3312
* Added unit tests for captures_per_hour

* Avoid useless overhead when no output configured

* Added default config values in documentation

* Fixed issue with title updating on Windows

* See https://github.com/PokemonGoF/PokemonGo-Bot/pull/3472

* Update installation docs to reflect setup sh changes (#3567)

* Fixed chmod in setup.sh (#3565)

* forgot to include the config location

* fixed setup files

* Updated readme to have better readability (#3569)

* Made the READ me more read friendly and compactor.

* Update README.md

* Update README.md

* Update README.md

* Update README.md

* Update faq.md

* More documentation changes making it noob proof(er) (#3575)

* added information on what what does

* add a link to the docker hub for NAS users.

* Update Readme to point to the latest wiki and documentation (#3579)

* Improve Docker Image and `docker-compose.yml` (#3583)

- Use the non-`onbuild` variant of the python base image to better make use of Docker image caching
 - Update some volumes in `docker-compose.yml` for pogoweb

* Small fixes and improvments in setup.sh (#3585)

Adding -p to mkdir - it will not show "already exist folder" error.
And adding to backup *gpx and path files.

* Remove the "evolve_captured" flag in favor of the EvolveTask (#3530)

* Remove the "evolve_captured" flag in favor of the EvolveTask

* Remove unused event

* Warn the user instead of stopping the bot

* Improved documentation (#3604)

- Improved read flow
- Added volume sharing of cache folder

* Update installation.md (#3618)

* Update installation.md

Changed the linux Section and the Ubuntu example, for easyer access
(if anyone now how to make a code block collapsable feel free)

* Update installation.md

removed pastebin link (cause i put it there in the first place) because it's not needed
edittet linux section to Installation Linux on the example of Ubuntu (merged it with ubuntu install section)

i hope i didn't miss anything

will check on mac and windows in the next 24h. I will make a new pr for that and link it here

* moving_to_fort and moving_to_lured_fort now also emit current_position (#3614)

arrived_at_fort emits position

* Fix handle soft ban (#3629)

* Fix `MoveToFort.config` None to Empty {} dict

Whenever the bot ticks, `config.get('enable', True)` is required

* Add new contributor

* [config] new tasks in example files (#3457)

* add UpdateTitleStats to config examples

* add UpdateTitleStats to config examples

* add SleepSchedule to config examples

all config files are missing SleepSchedule from task
see https://github.com/PokemonGoF/PokemonGo-Bot/pokemongo_bot/cell_workers/sleep_schedule.py for more info
,
      {
        "type": "SleepSchedule",
        "config": {
          "time": "22:54",
          "duration":"7:46",
          "time_random_offset": "00:24",
          "duration_random_offset": "00:43"
        }
      },

* Forgot one

* fix for changes in #3467

* disable new tasks by default, removed duplicate