### PR TITLE
added logic to support both master and dev branch or different fork

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 # 
 # docker build --build-arg BUILD_BRANCH=dev .
 # 
-# You can also build from different fork and ispecify a particular commit as the branch
+# You can also build from different fork and specify a particular commit as the branch
 # 
 # docker build  --build-arg BUILD_REPO=YourFork/PokemonGo-Bot --build-arg BUILD_BRANCH=6a4580f .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,8 @@ ENV BUILD_BRANCH ${BUILD_BRANCH:-master}
 ARG BUILD_REPO
 ENV BUILD_REPO ${BUILD_REPO:-PokemonGoF/PokemonGo-Bot}
 
+LABEL build_repo=$BUILD_REPO build_branch=$BUILD_BRANCH
+
 ADD https://github.com/$BUILD_REPO/archive/$BUILD_BRANCH.tar.gz .
 RUN tar -zxvf $BUILD_BRANCH.tar.gz && mv PokemonGo-Bot-* /usr/src/app && rm $BUILD_BRANCH.tar.gz
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,30 @@
+# To build a docker container for the "master" branch (this is the default) execute:
+#
+# docker build --build-arg BUILD_BRANCH=master .
+# (or)
+# docker build .
+#
+# To build a docker container for the "dev" branch execute:
+# 
+# docker build --build-arg BUILD_BRANCH=dev .
+# 
+# You can also build from different fork and ispecify a particular commit as the branch
+# 
+# docker build  --build-arg BUILD_REPO=YourFork/PokemonGo-Bot --build-arg BUILD_BRANCH=6a4580f .
+
+
 FROM python:2.7.12-alpine
 
 RUN apk add --update --no-cache alpine-sdk git
 
-ADD https://github.com/PokemonGoF/PokemonGo-Bot/archive/dev.tar.gz .
-RUN tar -zxvf dev.tar.gz && mv PokemonGo-Bot-dev /usr/src/app && rm dev.tar.gz
+ARG BUILD_BRANCH
+ENV BUILD_BRANCH ${BUILD_BRANCH:-master}
+
+ARG BUILD_REPO
+ENV BUILD_REPO ${BUILD_REPO:-PokemonGoF/PokemonGo-Bot}
+
+ADD https://github.com/$BUILD_REPO/archive/$BUILD_BRANCH.tar.gz .
+RUN tar -zxvf $BUILD_BRANCH.tar.gz && mv PokemonGo-Bot-* /usr/src/app && rm $BUILD_BRANCH.tar.gz
 
 WORKDIR /usr/src/app
 VOLUME ["/usr/src/app/configs", "/usr/src/app/web"]
@@ -24,6 +45,12 @@ ENV LD_LIBRARY_PATH /usr/src/app
 
 RUN ln -s /usr/include/locale.h /usr/include/xlocale.h
 RUN pip install --no-cache-dir -r requirements.txt
+
+#remove unused stuff
+RUN apk del alpine-sdk\
+  && rm -rf /var/cache/apk/*
+
+ENTRYPOINT ["python", "pokecli.py"]
 
 #remove unused stuff
 RUN apk del alpine-sdk\


### PR DESCRIPTION
## Short Description:
added logic to support both master and dev branch or different fork via --build-arg

## Fixes
- default: it builds the container from main repo master branch
- use --build-arg BUILD_BRANCH to specify branch
- use --build-arg BUILD_REPO to build from different fork
